### PR TITLE
Scope change for method processCmdLine (String[] args)

### DIFF
--- a/src/main/java/org/powertac/server/CompetitionSetupService.java
+++ b/src/main/java/org/powertac/server/CompetitionSetupService.java
@@ -116,7 +116,7 @@ public class CompetitionSetupService
    * Processes command-line arguments, which means looking for the specified 
    * script file and processing that
    */
-  void processCmdLine (String[] args)
+  public void processCmdLine (String[] args)
   {
     // pick up and process the command-line arg if it's there
     if (args.length > 1) {


### PR DESCRIPTION
Visualizer is not able to see this method so I propose the scope change from package-private to public.

Cheers,
Jurica
