### PR TITLE
#504 - LogServiceTests modified, to make testDefaultLogging() pass.

### DIFF
--- a/src/test/java/org/powertac/server/LogServiceTests.java
+++ b/src/test/java/org/powertac/server/LogServiceTests.java
@@ -64,6 +64,8 @@ public class LogServiceTests
   @Test
   public void testDefaultLogging ()
   {
+    // reinitialize the log service
+    logService = new LogService("src/test/resources/log4j.properties");
     assertNotNull("log service got created", logService);
     
     // log to the default trace file, check file


### PR DESCRIPTION
Reinitializing the logService in testDefaultLogging test will ensure that there are default file appenders log/test.trace and log/test.state for testDefaultLogging test.

Cheers,
Jurica
